### PR TITLE
updated to use ref object not string and hooks

### DIFF
--- a/react-integration-examples/src/App.js
+++ b/react-integration-examples/src/App.js
@@ -14,7 +14,15 @@ const editorStyle = {
 
 export default App = () => {
   const editorRef = useRef(null);
-
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        <h1 className="App-title">Welcome to React</h1>
+      </header>
+      <div style={editorStyle} ref={editorRef} touch-action="none" />
+    </div>
+  );
   useEffect(() => {
     let editor = editorRef.current;
     editor = MyScriptJS.register(editorRef.current, {
@@ -27,19 +35,9 @@ export default App = () => {
           host: 'webdemoapi.myscript.com',
           applicationKey: '1463c06b-251c-47b8-ad0b-ba05b9a3bd01',
           hmacKey: '60ca101a-5e6d-4159-abc5-2efcbecce059',
-        }
-      }
+        },
+      },
     });
     window.addEventListener("resize", () => {editor && editor.resize()});
   }, []);
-
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <h1 className="App-title">Welcome to React</h1>
-      </header>
-      <div style={editorStyle} ref={editorRef} touch-action="none" />
-    </div>
-  );
 }

--- a/react-integration-examples/src/App.js
+++ b/react-integration-examples/src/App.js
@@ -1,4 +1,4 @@
-import React,import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import * as MyScriptJS from 'myscript'

--- a/react-integration-examples/src/App.js
+++ b/react-integration-examples/src/App.js
@@ -29,7 +29,7 @@ export default App = () => {
           hmacKey: '60ca101a-5e6d-4159-abc5-2efcbecce059',
         }
       }
-    } );
+    });
     window.addEventListener("resize", () => {editor && editor.resize()});
   }, []);
 

--- a/react-integration-examples/src/App.js
+++ b/react-integration-examples/src/App.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React,import React, { useRef, useEffect } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import * as MyScriptJS from 'myscript'

--- a/react-integration-examples/src/App.js
+++ b/react-integration-examples/src/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useRef, useEffect } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import * as MyScriptJS from 'myscript'
@@ -12,21 +12,12 @@ const editorStyle = {
   'touch-action': 'none',
 };
 
-class App extends Component {
-  render() {
-    return (
-      <div className="App">
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <h1 className="App-title">Welcome to React</h1>
-        </header>
-        <div style={editorStyle} ref="editor" touch-action="none">
-        </div>
-      </div>
-    );
-  }
-  componentDidMount() {
-    this.editor = MyScriptJS.register(this.refs.editor, {
+const App = () => {
+  const editorRef = useRef(null);
+
+  useEffect(() => {
+    let editor = editorRef.current;
+    editor = MyScriptJS.register(editorRef.current, {
       recognitionParams: {
         type: 'TEXT',
         protocol: 'WEBSOCKET',
@@ -38,9 +29,20 @@ class App extends Component {
           hmacKey: '60ca101a-5e6d-4159-abc5-2efcbecce059',
         },
       },
-    });
-    window.addEventListener("resize", () => {this.editor.resize()});
-  }
+    } );
+    window.addEventListener("resize", () => {editor && editor.resize()});
+  }, []);
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        <h1 className="App-title">Welcome to React</h1>
+      </header>
+      <div style={editorStyle} ref={editorRef} touch-action="none">
+      </div>
+    </div>
+  );
 }
 
 export default App;

--- a/react-integration-examples/src/App.js
+++ b/react-integration-examples/src/App.js
@@ -9,10 +9,10 @@ const editorStyle = {
   'minHeight': '100px',
   'width': '100vw',
   'height': 'calc(100vh - 190px)',
-  'touch-action': 'none',
+  'touchAction': 'none',
 };
 
-const App = () => {
+export default App = () => {
   const editorRef = useRef(null);
 
   useEffect(() => {
@@ -27,8 +27,8 @@ const App = () => {
           host: 'webdemoapi.myscript.com',
           applicationKey: '1463c06b-251c-47b8-ad0b-ba05b9a3bd01',
           hmacKey: '60ca101a-5e6d-4159-abc5-2efcbecce059',
-        },
-      },
+        }
+      }
     } );
     window.addEventListener("resize", () => {editor && editor.resize()});
   }, []);
@@ -39,10 +39,7 @@ const App = () => {
         <img src={logo} className="App-logo" alt="logo" />
         <h1 className="App-title">Welcome to React</h1>
       </header>
-      <div style={editorStyle} ref={editorRef} touch-action="none">
-      </div>
+      <div style={editorStyle} ref={editorRef} touch-action="none" />
     </div>
   );
 }
-
-export default App;


### PR DESCRIPTION
Hi team,

I noticed the react example is quite outdated with the use of named refs `ref="string"` rather than the use of an object `ref={object}`. Whilst making this change I also upgraded to use the new react hooks API

https://reactjs.org/docs/refs-and-the-dom.html
https://reactjs.org/docs/hooks-intro.html